### PR TITLE
Fixes bug with pino logger config sending logs to gcp error reporting…

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -55,6 +55,7 @@ export const getLoggerConfig = (opts: LoggerOpts): Partial<LoggerOptions> => {
 					switch (label) {
 						case 'debug':
 						case 'info':
+							return { severity: label.toUpperCase() }
 						case 'error':
 							return { severity: label.toUpperCase(), ...errorReportingFields }
 						case 'warn':


### PR DESCRIPTION
## What this PR does

- [ ] Fixes bug with pino logger config sending logs to gcp error reporting for `INFO` and `DEBUG` log levels 

## References

- Fixes READ-63
